### PR TITLE
Hide curl download status on ssh login

### DIFF
--- a/lib/googlecloudsdk/command_lib/compute/ssh_utils.py
+++ b/lib/googlecloudsdk/command_lib/compute/ssh_utils.py
@@ -872,7 +872,7 @@ class BaseSSHCLIHelper(BaseSSHHelper):
     # Exit codes 255 and 1 are taken by OpenSSH and PuTTY.
     # 23 chosen by fair dice roll.
     remote_command = [
-        '[ `curl "{}" -H "Metadata-Flavor: Google" -q` = {} ] || exit 23'
+        '[ `curl -s "{}" -H "Metadata-Flavor: Google" -q` = {} ] || exit 23'
         .format(metadata_id_url, instance_id)]
     cmd = ssh.SSHCommand(remote, identity_file=identity_file,
                          options=options, remote_command=remote_command)


### PR DESCRIPTION
When using `gcloud compute ssh` on each login a `curl` download status is displayed, which just looks bad and doesn't provide any information. This should remove that.